### PR TITLE
Update the runtime version from 6.9 to 6.10, and more

### DIFF
--- a/io.github.streetpea.Chiaki4deck.yaml
+++ b/io.github.streetpea.Chiaki4deck.yaml
@@ -1,9 +1,9 @@
 app-id: io.github.streetpea.Chiaki4deck
 runtime: org.kde.Platform
-runtime-version: '6.9'
+runtime-version: '6.10'
 sdk: org.kde.Sdk
 base: io.qt.qtwebengine.BaseApp
-base-version: '6.9'
+base-version: '6.10'
 command: chiaki
 rename-icon: chiaking
 rename-desktop-file: chiaking.desktop
@@ -30,15 +30,17 @@ finish-args:
   - --filesystem=xdg-documents
   - --filesystem=~/.steam/steam
 
+cleanup:
+  - /include
+  - /lib/cmake
+  - /lib/pkgconfig
+  - /share/doc
+  - /share/man
+  - '*.la'
+  - '*.a'
 cleanup-commands:
   - /app/cleanup-BaseApp.sh
 
-build-options:
-  arch:
-    aarch64:
-      prepend-pkg-config-path: "/app/lib/pkgconfig:/app/lib64/pkgconfig:/app/lib/aarch64-linux-gnu/pkgconfig:/app/lib64/aarch64-linux-gnu/pkgconfig"
-    x86_64:
-      prepend-pkg-config-path: "/app/lib/pkgconfig:/app/lib64/pkgconfig:/app/lib/x86_64-linux-gnu/pkgconfig:/app/lib64/x86_64-linux-gnu/pkgconfig"
 modules:
   - name: protobuf-compilers
     buildsystem: cmake-ninja
@@ -47,35 +49,27 @@ modules:
       - -Dprotobuf_BUILD_SHARED_LIBS=OFF
       - -Dprotobuf_BUILD_PROTOBUF_BINARIES=ON
       - -Dprotobuf_BUILD_EXAMPLES=OFF
-    cleanup:
-      - /include
-      - /lib/*.a
-      - /lib/cmake
-      - /lib/pkgconfig
     sources:
       - type: archive
         url: https://github.com/protocolbuffers/protobuf/releases/download/v21.12/protobuf-cpp-3.21.12.tar.gz
         sha256: 4eab9b524aa5913c6fffb20b2a8abf5ef7f95a80bc0701f3a6dbb4c607f73460
 
+  # Dependency of chiaki-ng/third-party/cpp-steam-tools
   - name: libplacebo
     buildsystem: meson
     config-opts:
       - -Dvulkan=enabled
       - -Dshaderc=enabled
-    cleanup:
-      - /include
-      - /lib/pkgconfig
     sources:
       - type: git
         url: https://github.com/haasn/libplacebo
         tag: v7.360.1
+        commit: cee9b076f2c63104ccfd497fa79c39a867293ec4
 
   - name: ffmpeg
     cleanup:
       - /bin/ffmpeg
       - /lib/*.so
-      - /include
-      - /lib/pkgconfig
       - /share/ffmpeg/examples
       - /share/ffmpeg
     config-opts:
@@ -96,51 +90,6 @@ modules:
       - type: patch
         path: 0001-vulkan-ignore-frames-without-hw-context.patch
 
-  - name: python3-google
-    buildsystem: simple
-    build-commands:
-      - "pip3 install --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} --no-build-isolation google"
-    sources:
-      - type: file
-        url: https://files.pythonhosted.org/packages/3e/db/5ba900920642414333bdc3cb397075381d63eafc7e75c2373bbc560a9fa1/soupsieve-2.0.1.tar.gz
-        sha256: a59dc181727e95d25f781f0eb4fd1825ff45590ec8ff49eadfd7f1a537cc0232
-      - type: file
-        url: https://files.pythonhosted.org/packages/e8/b0/cd2b968000577ec5ce6c741a54d846dfa402372369b8b6861720aa9ecea7/beautifulsoup4-4.11.1.tar.gz
-        sha256: ad9aa55b65ef2808eb405f46cf74df7fcb7044d5cbc26487f96eb2ef2e436693
-      - type: file
-        url: https://files.pythonhosted.org/packages/89/97/b49c69893cddea912c7a660a4b6102c6b02cd268f8c7162dd70b7c16f753/google-3.0.0.tar.gz
-        sha256: 143530122ee5130509ad5e989f0512f7cb218b2d4eddbafbad40fd10e8d8ccbe
-
-  - name: python3-protobuf
-    buildsystem: simple
-    build-commands:
-      - "pip3 install --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} --no-build-isolation protobuf"
-    sources:
-      - type: file
-        url: https://files.pythonhosted.org/packages/ba/dd/f8a01b146bf45ac12a829bbc599e6590aa6a6849ace7d28c42d77041d6ab/protobuf-4.21.12.tar.gz
-        sha256: 7cd532c4566d0e6feafecc1059d04c7915aec8e182d1cf7adee8b24ef1e2e6ab
-
-  - name: python3-requests
-    buildsystem: simple
-    build-commands:
-      - "pip3 install --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} --no-build-isolation requests"
-    sources:
-      - type: file
-        url: https://files.pythonhosted.org/packages/ea/b7/e0e3c1c467636186c39925827be42f16fee389dc404ac29e930e9136be70/idna-2.10.tar.gz
-        sha256: b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6
-      - type: file
-        url: https://files.pythonhosted.org/packages/da/67/672b422d9daf07365259958912ba533a0ecab839d4084c487a5fe9a5405f/requests-2.24.0.tar.gz
-        sha256: b3559a131db72c33ee969480840fff4bb6dd111de7dd27c8ee1f820f4f00231b
-      - type: file
-        url: https://files.pythonhosted.org/packages/40/a7/ded59fa294b85ca206082306bba75469a38ea1c7d44ea7e1d64f5443d67a/certifi-2020.6.20.tar.gz
-        sha256: 5930595817496dd21bb8dc35dad090f1c2cd0adfaf21204bf6732ca5d8ee34d3
-      - type: file
-        url: https://files.pythonhosted.org/packages/81/f4/87467aeb3afc4a6056e1fe86626d259ab97e1213b1dfec14c7cb5f538bf0/urllib3-1.25.10.tar.gz
-        sha256: 91056c15fa70756691db97756772bb1eb9678fa585d9184f24534b100dc60f4a
-      - type: file
-        url: https://files.pythonhosted.org/packages/fc/bb/a5768c230f9ddb03acc9ef3f0d4a3cf93462473795d18e9535498c8f929d/chardet-3.0.4.tar.gz
-        sha256: 84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae
-
   - name: hidapi
     buildsystem: cmake-ninja
     config-opts:
@@ -149,10 +98,9 @@ modules:
       - type: git
         url: https://github.com/libusb/hidapi.git
         tag: hidapi-0.15.0
-    cleanup:
-      - /lib/*.la
-      - /lib/pkgconfig
-      - /include
+        commit: d6b2a974608dec3b76fb1e36c189f22b9cf3650c
+
+  - python3-modules.yaml
 
   - name: speexDSP
     buildsystem: simple
@@ -165,13 +113,17 @@ modules:
       - type: git
         url: https://gitlab.xiph.org/xiph/speexdsp.git
         tag: SpeexDSP-1.2.1
+        commit: 1b28a0f61bc31162979e1f26f3981fc3637095c8
 
   - name: json-c
     buildsystem: cmake-ninja
+    config-opts:
+      - -DCMAKE_POLICY_VERSION_MINIMUM=3.5
     sources:
       - type: git
         url: https://github.com/json-c/json-c.git
         tag: json-c-0.18-20240915
+        commit: 41a55cfcedb54d9c1874f2f0eb07b504091d7e37
 
   - name: miniupnpc
     buildsystem: cmake-ninja
@@ -179,8 +131,10 @@ modules:
     sources:
     - type: git
       url: https://github.com/miniupnp/miniupnp
-      tag: miniupnpc_2_3_0
+      tag: miniupnpd_2_3_10
+      commit: b5e5d2eb069822b7f00d56c8e61033b9d500e60c
 
+  # Use the latest version of SDL3 and SDL2-compat to fix visual gliches
   - name: SDL3
     buildsystem: cmake-ninja
     config-opts:
@@ -190,20 +144,23 @@ modules:
     sources:
       - type: git
         url: https://github.com/libsdl-org/SDL.git
-        tag: release-3.4.0
+        tag: release-3.4.8
+        commit: d9d5536704d585616d4db3c8ba3c4ff6fc2757e1
 
   - name: sdl2-compat
-    sources:
-      - type: git
-        url: https://github.com/libsdl-org/sdl2-compat
-        tag: release-2.32.64
     buildsystem: cmake-ninja
     config-opts:
       - -DSDL2COMPAT_TESTS=OFF
       - -DCMAKE_INSTALL_LIBDIR=lib
     post-install:
       - mv /app/lib/pkgconfig/sdl2-compat.pc /app/lib/pkgconfig/sdl2.pc
+    sources:
+      - type: git
+        url: https://github.com/libsdl-org/sdl2-compat
+        tag: release-2.32.68
+        commit: 84b4032aef2742f79bd7b4317a22b84b0fe14155
 
+  # NOTE: Undocumented action. Why it is required?
   - name: vulkanso
     buildsystem: simple
     build-commands:
@@ -211,12 +168,15 @@ modules:
 
   - name: chiaki-ng
     buildsystem: cmake-ninja
+    build-options:
+      cflags: -std=gnu11
     builddir: true
-    sources:
-      - type: git
-        url: https://github.com/streetpea/chiaki-ng.git
-        commit: c20ff6ac1b3f3a479c5004c74268025051cb109b
     post-install:
       - install -Dm755 ../scripts/psn-account-id.py /app/bin/psn-account-id
       - install -Dm755 ../scripts/vulkan-gamescope-layers/VkLayer_FROG_gamescope_wsi.x86_64.json
-        /app/share/vulkan/implicit_layer.d/VkLayer_FROG_gamescope_wsi.x86_64.json
+        -t /app/share/vulkan/implicit_layer.d/
+    sources:
+      - type: git
+        url: https://github.com/streetpea/chiaki-ng.git
+        tag: v1.10.0
+        commit: 0c4a45df0cae2af2ba2daef84e881850b07038a3

--- a/python3-modules.yaml
+++ b/python3-modules.yaml
@@ -1,0 +1,53 @@
+# Generated with flatpak-pip-generator google protobuf requests --yaml
+name: python3-modules
+buildsystem: simple
+build-commands: []
+modules:
+  - name: python3-google
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} "google" --no-build-isolation
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl
+        sha256: 0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb
+      - type: file
+        url: https://files.pythonhosted.org/packages/ac/35/17c9141c4ae21e9a29a43acdfd848e3e468a810517f862cad07977bf8fe9/google-3.0.0-py2.py3-none-any.whl
+        sha256: 889cf695f84e4ae2c55fbc0cfdaf4c1e729417fa52ab1db0485202ba173e4935
+      - type: file
+        url: https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl
+        sha256: ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95
+      - type: file
+        url: https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl
+        sha256: f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548
+  - name: python3-protobuf
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} "protobuf" --no-build-isolation
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/88/95/608f665226bca68b736b79e457fded9a2a38c4f4379a4a7614303d9db3bc/protobuf-7.34.1-py3-none-any.whl
+        sha256: bb3812cd53aefea2b028ef42bd780f5b96407247f20c6ef7c679807e9d188f11
+  - name: python3-requests
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} "requests" --no-build-isolation
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl
+        sha256: 3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a
+      - type: file
+        url: https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl
+        sha256: 3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d
+      - type: file
+        url: https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl
+        sha256: 048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8
+      - type: file
+        url: https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl
+        sha256: 2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0
+      - type: file
+        url: https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl
+        sha256: 9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897


### PR DESCRIPTION
- Update the runtime version to 6.10
- Use top-level cleanup commands to reduce duplication
- Move python modules to the python-modules.yaml to generate using flatpak-pip-generator
- Add missing Commit IDs
- Update SDL3 and SDL2-compat versions
- Use the latest version of SDL3 and SDL2-compat to fix visual gliches
- Fix build errors
- Improve the manifest file
- Other trivial changes

**Please don't forget to test before merging. Please don't forget to test the stream functionality.** 